### PR TITLE
Allow disabling sentry integration via config

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -8,6 +8,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ConfigurationService
 {
+    const DISABLE_SENTRY = 'disableSentry';
+
     const DSN = 'dsn';
 
     const REPORT_USER_INFORMATION = 'reportUserInformation';
@@ -37,6 +39,11 @@ class ConfigurationService
         /** @var ExtensionConfiguration $extensionConfiguration */
         $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
         return $extensionConfiguration->get('sentry_client', $path);
+    }
+
+    public static function isDisabled(): bool
+    {
+        return (bool)getenv('SENTRY_DISABLE') || (bool)self::getExtensionConfiguration(self::DISABLE_SENTRY);
     }
 
     public static function getDsn(): ?string

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['YourVendor]['YourExtension]['Controller']['w
 * LogWriter Loglevel: If set, log messages are reported to Sentry
 * LogWriter Component blacklist
 
+### Disable in dev environments
+
+If you want to keep the extension installed and configured but want to disable it (i.e. temporarily or in certain
+TYPO3 contexts), you can either set the environment variable:
+
+```
+SENTRY_DISABLE=1
+```
+
+Or set it in TYPO3 based on some condition, for example in your `AdditionalConfiguration.php`
+aka `config/system/additional.php`:
+```php
+if (\TYPO3\CMS\Core\Core\Environment::getContext()->isDevelopment()) {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['sentry_client']['disableSentry'] = true;
+}
+```
+
 ### Request ID
 
 If the web server has set a request ID header `X-Request-Id`, this is transmitted as a tag to trace errors to logs.

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,5 +1,7 @@
 # cat=Sentry/; type=text; label=DSN: http://public_key@your-sentry-server.com/project-id, you can also use the SENTRY_DSN environment variable
 dsn =
+# cat=Sentry/; type=boolean; label=Disable sentry integration, even if the extension is installed (for example for dev environments)
+disableSentry = 0
 # cat=Sentry/; type=options[none,userid,usernameandemail]; label=Report user information
 reportUserInformation = userid
 # cat=Sentry/; type=text; label=Exception/LogWriter message blacklist regex: Use it to not report them. Example: /an exception message/

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,10 @@
 defined('TYPO3') or die();
 
 call_user_func(function() {
+    if (\Networkteam\SentryClient\Service\ConfigurationService::isDisabled()) {
+        return;
+    }
+
     if (!\TYPO3\CMS\Core\Core\Environment::isComposerMode()) {
         $autoloadFile = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('sentry_client') . 'vendor/autoload.php';
         require_once($autoloadFile);
@@ -20,7 +24,9 @@ call_user_func(function() {
             ],
         ];
     }
+});
 
+call_user_func(function() {
     if (version_compare(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getNumericTypo3Version(), '11', '<')) {
         $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
             \TYPO3\CMS\Core\Imaging\IconRegistry::class


### PR DESCRIPTION
See upstream PR: https://github.com/networkteam/sentry_client/pull/87

Allow switching it off via extension configuration (`disableSentry`) or environment variable (`SENTRY_DISABLE`). Default is backwards compatible (enabled).

Either set the environment variable:
```
SENTRY_DISABLE=1
```

Or set it in TYPO3 based on some condition, for example in your `AdditionalConfiguration.php`
aka `config/system/additional.php`:
```php
if (\TYPO3\CMS\Core\Core\Environment::getContext()->isDevelopment()) {
    $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['sentry_client']['disableSentry'] = true;
}
```